### PR TITLE
chore: add gzip compression to nginx conf

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,6 +7,37 @@ server {
     root   /usr/share/nginx/html;
     index  index.html;
 
+    ##
+    # Gzip Settings
+    ##
+
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_min_length 256;
+    gzip_comp_level 2;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types
+        application/atom+xml
+        application/javascript
+        application/json
+        application/manifest+json
+        application/rss+xml
+        application/x-font-ttf
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        font/opentype
+        image/bmp
+        image/svg+xml
+        image/x-icon
+        text/cache-manifest
+        text/css
+        text/plain;
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
### What does it fix?
- Adds gzip compression to nginx configuration

While doing some audits I noticed that we don't have file compression yet added to the project.
I tried to add the most common types. Please let me know if you think we should cover more.
- https://tools.pingdom.com/#5c45f74ce7800000
- https://www.webpagetest.org/result/200326_CG_321e04ad16635c34dd4abd0ae550a55c/1/performance_optimization/

According to Google PageSpeed Insights we could save up to 4s load time on mobile devices by enabling compression:

-----

![Screenshot 2020-03-27 at 00 24 14](https://user-images.githubusercontent.com/1295800/77706061-9953d200-6fc1-11ea-94ec-6f604dd6b001.png)

----

