### PR TITLE
Use version 2 of checkout GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkoout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Build Docker image
         run: |
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkoout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Build Docker image
         run: |
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkoout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Build Docker image
         run: |
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set env to staging
         if: endsWith(github.ref, '/develop')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkoout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Build Docker image
         run: |
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkoout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Build Docker image
         run: |
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkoout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Build Docker image
         run: |
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: "Prep TF Vars"
         run: |


### PR DESCRIPTION
Version 2 of `checkout` GHA fixes the checkout from Workflows triggered from forked repos.