### PR TITLE
Specify which folder we use to install dev dependencies

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,11 +17,11 @@ serve it in form of an API to this frontend app.
 
 ## Dependencies
 
-We use `yarn` so you should [install that first](https://classic.yarnpkg.com/en/docs/install#mac-stable) if you don't already have it.
+We use `yarn` so you should [install that first](https://classic.yarnpkg.com/en/docs/install#mac-stable) if you don't already have it. 
 
 ## Install project dependencies
 
-While in this directory, you can run this:
+While in **frontend** directory, you can run this:
 
 ```
 yarn


### PR DESCRIPTION

### What does it fix?

I add the folder name 'frontend'.
