### PR TITLE
Keep navigation buttons on bottom

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4528,6 +4528,11 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "downloadjs": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw="
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/frontend/src/components/cards/perday-table/perday-table.css
+++ b/frontend/src/components/cards/perday-table/perday-table.css
@@ -2,6 +2,7 @@
     max-width: 100%;
     width: 100%;
     min-height: 500px;
+    position: relative;
 }
 
 .perDayTable table {
@@ -40,6 +41,14 @@
 }
 .perDayTable .button:first-child {
     margin-right: 10px;
+}
+
+.perDayTable .navigation {
+    position: absolute;
+    bottom: 5px;
+    display: block;
+    width: 100%;
+    min-width: 100%;
 }
 
 .navigation-chevron{

--- a/frontend/src/components/cards/perday-table/perday-table.jsx
+++ b/frontend/src/components/cards/perday-table/perday-table.jsx
@@ -46,7 +46,7 @@ export class PerDayTable extends React.PureComponent {
         const shouldDisplayPagination = data.length > limit;
 
         if (shouldDisplayPagination) {
-            return <div>
+            return <div className="navigation">
                 <div className={"button " + (page === 0 ? "hide" : "")} onClick={e => this.changePage(-1)}>
                     <img
                         src="/images/chevrons-left.svg"


### PR DESCRIPTION
### Requirements for making a pull request

Atunci cand se navigheaza intre 2 pagini la nivel de tabel, butoanele de inainte/inapoi se muta in functie de inaltimea tabelului.

### What does it fix?

Indiferent de inaltimea tabelului, navigarea ramane fixa.

Inainte:
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/4411836/78017348-d1a63800-7354-11ea-8f9d-2b91fbb0aaa0.png">


Dupa:
<img width="1340" alt="image" src="https://user-images.githubusercontent.com/4411836/78017281-b4716980-7354-11ea-87b9-3e1d1a6d035e.png">

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/4411836/78017320-bf2bfe80-7354-11ea-9df4-0328b3c7e8ff.png">


