### PR TITLE
Rotated labels for chart

### DIFF
--- a/frontend/src/components/cards/cases-per-day-card/cases-per-day-card.jsx
+++ b/frontend/src/components/cards/cases-per-day-card/cases-per-day-card.jsx
@@ -20,7 +20,10 @@ export class CasesPerDayCard extends React.PureComponent {
         type: 'category',
         data: state.dates,
         axisLabel: {
-          color: 'gray'
+          color: 'gray',
+          fontWeight: 'bold',
+          rotate: 45,
+          interval: 0
         }
       },
       yAxis: {


### PR DESCRIPTION
### What does it fix?

Rotated labels for daily chart x axis; forced them to show for every bar;

### How has it been tested?

Manually