### PR TITLE
Sort age histogram by 'processing' key

### DIFF
--- a/frontend/src/components/pages/dashboard.jsx
+++ b/frontend/src/components/pages/dashboard.jsx
@@ -227,11 +227,11 @@ class DashboardNoContext extends React.PureComponent {
     const totalKnown = allValues.reduce((a, b) => a + b, 0);
     const knownPercentage =
       total > 0 ? 100 - Math.round((totalKnown / total) * 100) : 100;
-    const data = Object.keys(stats).map(key => ({
-      value: stats[key],
-      name: key,
-      percentage: Math.round((100 * stats[key]) / total)
-    }));
+    const data = Object.keys(stats).sort(key => (key === 'în procesare' ? -1 : 0)).map(key => ({
+        value: stats[key],
+        name: key,
+        percentage: Math.round(100 * stats[key] / total)
+      }));
 
     return {
       isLoaded: true,


### PR DESCRIPTION
### What does it fix?

Closes https://github.com/code4romania/date-la-zi/issues/285

- "Processing" line for the new age component should be the last one

### How has it been tested?

Manually testing