### PR TITLE
Update embed code and message

### DIFF
--- a/frontend/src/components/layout/embed-button/embed-button.jsx
+++ b/frontend/src/components/layout/embed-button/embed-button.jsx
@@ -23,7 +23,7 @@ export const EmbedButton = props => {
 
     auxiliaryField.remove();
 
-    toast.add('Textul a fost copiat in memoria clipboard');
+    toast.add('Codul de embed a fost copiat în clipboard');
   };
 
   // if already embedded hide the button

--- a/frontend/src/components/layout/embed-button/embed-button.jsx
+++ b/frontend/src/components/layout/embed-button/embed-button.jsx
@@ -7,15 +7,15 @@ export const EmbedButton = props => {
   const { path, viewPort } = props;
 
   const footerHeight = 75;
-  let getEmbeddableCode = () => `<iframe
+  const getEmbeddableCode = `<iframe
             scrolling="no"
             src="${window.location.origin.toString()}/embed/${path}"
             width="${viewPort.width}"
-            height="${viewPort.height + footerHeight}" />`;
+            height="${viewPort.height + footerHeight}"></iframe>`;
 
   const handleCopyEmbedCode = () => {
     const auxiliaryField = document.createElement('textarea');
-    auxiliaryField.innerText = getEmbeddableCode();
+    auxiliaryField.innerText = getEmbeddableCode.replace(/\s+(?=\s)/g, '');
 
     document.body.appendChild(auxiliaryField);
     auxiliaryField.select();


### PR DESCRIPTION
This PR changes the wording of the on-copy message and cleans up the generated iframe code, stripping extra whitespace and closing the iframe tag, which is not a [void element](https://www.w3.org/TR/2011/WD-html-markup-20110405/syntax.html#syntax-elements), so it can't self-close.


before:
```html
<iframe            scrolling="no"            src="https://datelazi.ro/embed/confirmed_cases"            width="422"            height="244" />
```

after:
```html
<iframe scrolling="no" src="https://datelazi.ro/embed/confirmed_cases" width="422" height="244"></iframe>
```
