### PR TITLE
Updated about link in footer.jsx to point to /about

### DIFF
--- a/frontend/src/components/layout/footer/footer.jsx
+++ b/frontend/src/components/layout/footer/footer.jsx
@@ -13,7 +13,7 @@ const FooterWrapper = () => {
       <FooterLinks>
         <FooterLinkHeader>Link-uri utile</FooterLinkHeader>
         <FooterLinkItem>
-          <Link to="/despre">Despre proiect</Link>
+          <Link to="/about">Despre proiect</Link>
         </FooterLinkItem>
         <FooterLinkItem>
           <a


### PR DESCRIPTION
### What does it fix?

https://github.com/code4romania/date-la-zi/issues/318

Please mention the main changes this PR brings.
The PR changes the about link in footer.jsx to point to /about instead of /despre.

### How has it been tested?

I clicked on "Despre proiect" in the footer.