### PR TITLE
Created a hidden table for screen readers for 'Numar Cazuri pe zile'

### DIFF
--- a/frontend/src/components/cards/cases-per-day-card/cases-per-day-card.jsx
+++ b/frontend/src/components/cards/cases-per-day-card/cases-per-day-card.jsx
@@ -208,9 +208,53 @@ export class CasesPerDayCard extends React.PureComponent {
           option={this.getChartOptions(records)}
           theme="light"
         />
-
+        <AccessibillityCasesPerDayTable
+          dates={this.getPage(records.dates, ' ')}
+          listConfirmed={this.getPage(records.confirmedCasesHistory)}
+          listCured={this.getPage(records.curedCasesHistory)}
+          listDeaths={this.getPage(records.deathCasesHistory)}
+        />
         {this.displayPagination(records.dates, isLoaded)}
       </Card>
     );
   }
 }
+
+/*
+A table containg the data from cases-per-day-card that is hidden and can be only 
+accessed by screen readers
+*/
+const AccessibillityCasesPerDayTable = (props) => {
+  /*Putting the data from props inside one single array to use map inside the return function*/
+  const records = [];
+  for (let i = props.dates.length - 1; i >= 0; i--) {
+    if (props.dates[i] === ' ') {
+      break;
+    }
+    records.push({
+      date: props.dates[i],
+      confirmed: props.listConfirmed[i],
+      cured: props.listCured[i],
+      deaths: props.listDeaths[i],
+    });
+  }
+  return (
+    <table role="table" style={{ position: 'absolute', left: -99999 }}>
+      <tr role="row">
+        <th role="columnheader">Dată</th>
+        <th role="columnheader">Confirmaţi</th>
+        <th role="columnheader">Vindecaţi</th>
+        <th role="columnheader">Decedaţi</th>
+      </tr>
+      {records.map((record) => (
+        <tr role="row" key={record.id}>
+          <td role="cell">{record.date}</td>
+          <td role="cell">{record.confirmed}</td>
+          <td role="cell">{record.cured}</td>
+          <td role="cell">{record.deaths}</td>
+        </tr>
+      ))}
+    </table>
+  );
+};
+


### PR DESCRIPTION
https://github.com/code4romania/date-la-zi/issues/324

This PR adds a table with the data from "Numar Cazuri pe zile" witch is hidden for accessibility purposes, the table is hidden for the regular user, but a user with a screen reader can access data from it.

| How the table looks when it's not hidden | How the page looks when the table is hidden |
| ------------- | ------------- |
| ![Screenshot 2020-04-25 at 17 43 11](https://user-images.githubusercontent.com/44275480/80284606-3bcdb500-8728-11ea-939b-ef69d6059d9a.png) | ![Screenshot 2020-04-25 at 17 42 38](https://user-images.githubusercontent.com/44275480/80284614-4720e080-8728-11ea-9f6b-4eaa8f713904.png)  |

### How has it been tested?
I tested it in Brave bowser with ChromeVox extension and in Safari with Apple VoiceOver, and the data can be accessed properly with screen readers.
